### PR TITLE
Upsert revision to MAX.

### DIFF
--- a/packages/framework/storage/__tests__/query.test.js
+++ b/packages/framework/storage/__tests__/query.test.js
@@ -53,20 +53,13 @@ describe('Query modules', () => {
         rate: 12,
       });
 
-      let query;
       const createQuery = createPromoteRevision('video');
 
-      query = createQuery(model, 1);
+      const query = createQuery(model);
       expect(query.text).toEqual(
-        'INSERT INTO video (id, revision) VALUES($1, $2)'
+        'INSERT INTO video (id, revision) SELECT id, MAX(revision) FROM video_revision WHERE id = $1 GROUP BY id ON CONFLICT (id) DO UPDATE SET revision = excluded.revision'
       );
-      expect(query.values).toEqual(['01837ed6-ee3e-11e8-b6f6-00090ffe0001', 1]);
-
-      query = createQuery(model, 2);
-      expect(query.text).toEqual(
-        'UPDATE video SET revision = $2 WHERE id = $1'
-      );
-      expect(query.values).toEqual(['01837ed6-ee3e-11e8-b6f6-00090ffe0001', 2]);
+      expect(query.values).toEqual(['01837ed6-ee3e-11e8-b6f6-00090ffe0001']);
     });
   });
 

--- a/packages/framework/storage/adapter.js
+++ b/packages/framework/storage/adapter.js
@@ -129,11 +129,8 @@ function createRevisionedStorageAdapter(Model, tableName) {
       try {
         await this.db.query('BEGIN');
 
-        const result = await this.db.query(Query.storeRevision(model));
-
-        const { revision } = result.rows[0];
-
-        await this.db.query(Query.promoteRevision(model, revision));
+        await this.db.query(Query.storeRevision(model));
+        await this.db.query(Query.promoteRevision(model));
 
         await this.db.query('COMMIT');
       } catch (error) {


### PR DESCRIPTION
This PR avoids a race condition by upserting revision count to the highest number found. Regardless of which client promotes revision it will generate the same result.